### PR TITLE
feat(tools): Intelligent defaults for project setup, more validation

### DIFF
--- a/tools/gulp/env.ts
+++ b/tools/gulp/env.ts
@@ -17,7 +17,7 @@ let knownOptions = {
     'project': 'p'
   },
   boolean: ['dev', 'prod', 'force'],
-  'default': {dev: false, prod: false, force: false, env: 'dev'}
+  'default': {dev: false, prod: false, force: false}
 };
 
 
@@ -27,17 +27,16 @@ export class Environment {
   constructor() {
     this.options = <any>minimist(process.argv.slice(2), knownOptions);
     if (!this.options.env) {
-      if (this.options.dev) {
-        this.options.env = 'dev'
-      } else if (this.options.prod) {
+      if (this.options.prod) {
         this.options.env = 'prod'
       } else {
-        throw new Error('Environment not specified. Provide flag --prod, --dev, or specify with --env=\'foo\'')
+        this.options.env = 'dev'
       }
     }
     if(this.options.p){
       this.options.project = this.options.p
     }
+    console.log('=info=', `Current environment set to ${this.options.env}`)
   }
 
   env(): string {

--- a/tools/gulp/project/exception/firebase-private-key-mismatch.ts
+++ b/tools/gulp/project/exception/firebase-private-key-mismatch.ts
@@ -1,0 +1,11 @@
+import {TangentialError} from './tangential-error';
+
+export class FirebasePrivateKeyMismatch extends TangentialError {
+
+  constructor(message: string) {
+    super(message);
+  }
+
+
+
+}

--- a/tools/gulp/project/exception/tangential-error.ts
+++ b/tools/gulp/project/exception/tangential-error.ts
@@ -9,9 +9,9 @@ export class TangentialError extends Error {
 
   static handle(e: any) {
     if (e.name == TangentialError.name) {
-      console.error(e.message)
+      console.error('=error=', e.message)
     } else {
-      console.error('Unhandled Error:', e)
+      console.error('=error=', 'Unhandled Error:', e)
     }
   }
 }

--- a/tools/gulp/project/firebase.gulp.ts
+++ b/tools/gulp/project/firebase.gulp.ts
@@ -6,18 +6,12 @@ import {TangentialError} from './exception/tangential-error';
 task('firebase:push-project-users', (done: any) => {
   let p = Project.load(Env.projectFile())
   let pEnv = p.currentEnvironment()
-
   pEnv.firebase.pushProjectUsersToRemote().then(() => {
     console.log(`Remote users pushed to firebase authentication table: `
       + `https://console.firebase.google.com/project/${pEnv.firebase.config.projectId}/authentication/users `)
-    done()
   }).catch((e: any) => {
-    if (e.name == TangentialError.name) {
-      console.error(e.message)
-    } else {
-      console.error('Unhandled Error:', e)
-    }
-  })
+    TangentialError.handle(e)
+  }).then(() => done())
 });
 
 task('firebase:take-database-backup', (done: any) => {
@@ -29,16 +23,14 @@ task('firebase:take-database-backup', (done: any) => {
     } else {
       console.log(`There was no data to back up.`)
     }
-    done()
   }, (e: any) => {
-    console.log('Backup failed: ', e)
-  })
+    TangentialError.handle(e)
+  }).then(() => done())
 });
 
 task('firebase:push-database-template', (done: any) => {
   let p = Project.load(Env.projectFile())
   let pEnv = p.currentEnvironment()
-
   pEnv.firebase.pushDatabaseTemplateToRemote(Env.force).then((written: boolean) => {
     if (written) {
       console.log(`Remote data was successfully written: `
@@ -46,13 +38,12 @@ task('firebase:push-database-template', (done: any) => {
     } else {
       console.log(`Remote data was not written. See previous log messages.`)
     }
-    done()
   }).catch((e: any) => {
-    if (e.name == TangentialError.name) {
-      console.error(e.message)
-    } else {
-      console.error('Unhandled Error:', e)
-    }
+    TangentialError.handle(e)
+  }).then(() => {
+    console.log('Done?', 'Not done')
+    done()
+    process.exit(0)
   })
 });
 

--- a/tools/gulp/project/firebase/remote-project-util.ts
+++ b/tools/gulp/project/firebase/remote-project-util.ts
@@ -1,0 +1,166 @@
+import fs = require('fs');
+import {FirebaseEnvironment} from '../model/firebase/firebase-environement';
+import {JSON_FILE_WRITE_CONFIG} from '../../constants';
+import {Project} from '../model/project';
+import {ProjectEnvironment} from '../model/project-environment';
+
+const jsonFile = require('jsonfile');
+
+import * as admin from 'firebase-admin'
+
+
+let firebaseInitialized: boolean = false
+
+/**
+ *
+ */
+export class RemoteProjectUtil {
+
+
+  static pushAuthenticationUsersFromUsersFile(projectEnv: ProjectEnvironment, fbEnv: FirebaseEnvironment): Promise<boolean> {
+    const promises: Promise<void>[] = []
+    const auth = RemoteProjectUtil.getApp(fbEnv).auth()
+
+    projectEnv.projectUsers.forEach((user: any) => {
+      if (user.uid) {
+        const promise: Promise<void> = new Promise<void>((resolve, reject) => {
+          auth.getUser(user.uid).then(() => {
+            auth.updateUser(user.uid, user).then(() => resolve()).catch((e: any) => {
+              console.log('Error updating user: ', e)
+              reject(e)
+            })
+          }).catch((e: any) => {
+            // doesn't exist yet.
+            auth.createUser(user).then(() => resolve()).catch((error: any) => {
+              console.log('Error creating user: ', error)
+              reject(e)
+            })
+          })
+        })
+        promises.push(promise)
+      }
+    })
+    return Promise.all(promises).then(() => true)
+  }
+
+  static pushDatabase(project: Project, fbEnv: FirebaseEnvironment, force: boolean = false): Promise<boolean> {
+    const db:admin.database.Database = RemoteProjectUtil.getDb(fbEnv)
+    return new Promise<boolean>((resolve, reject) => {
+      const ref:firebase.database.Reference = db.ref('/');
+      let data: string = fbEnv.readDatabaseTemplate()
+
+      ref.once('value', (snapshot: any) => {
+        if (snapshot.exists()) {
+          if (force) {
+            console.log('Database already populated. Taking backup and forcing overwrite.')
+            fbEnv.takeBackupFromRemote(project.getBasePath()).then(() => {
+              RemoteProjectUtil.overwriteDatabaseWithTemplate(fbEnv).then(() => {
+                db.goOffline()
+                resolve(true)
+              })
+            })
+          } else {
+            console.log('Database already populated, aborting. To force re-initialization use the --force option.')
+            db.goOffline()
+            resolve(false)
+          }
+        } else {
+          console.log('Database is empty. Initializing...')
+          ref.set(data, (error: any) => {
+            if (error) {
+              this.logError(data, error)
+              reject(error)
+            } else {
+              console.log(`   pushed data to remote Firebase project.`)
+              resolve(true)
+            }
+            db.goOffline()
+          })
+        }
+      }, (error: any) => {
+        this.logError(data, error)
+        db.goOffline()
+        reject(error)
+      }).catch(e =>{
+        console.log('RemoteProjectUtil', 'what the hell')
+      })
+    });
+  }
+
+  static overwriteDatabaseWithTemplate(fbEnv: FirebaseEnvironment): Promise<boolean> {
+    const db = RemoteProjectUtil.getApp(fbEnv).database()
+    return new Promise<boolean>((resolve, reject) => {
+      let data = fbEnv.readDatabaseTemplate()
+      console.log('Attempting to initialize database: ')
+      db.goOnline()
+      db.ref('/').set(data, (error: any) => {
+        if (error) {
+          this.logError(data, error)
+          reject(error)
+        } else {
+          console.log(`   pushed data to remote Firebase project.`)
+          resolve(true)
+        }
+      })
+    });
+
+  }
+
+
+  static logError(authData, error) {
+    console.error('Error executing remote firebase operation:')
+    console.error('Using auth:', JSON.stringify(authData))
+    console.error('Native error: ', error)
+  }
+
+  static getApp(fbEnv: FirebaseEnvironment) {
+    if (!firebaseInitialized) {
+      let cfg = {
+        credential: admin.credential.cert(fbEnv.getPrivateKeyPath()),
+        databaseURL: 'https://' + fbEnv.config.projectId + '.firebaseio.com',
+        databaseAuthVariableOverride: {
+          uid: 'gulp-service-worker'
+        }
+      }
+      admin.initializeApp(cfg);
+      firebaseInitialized = true
+      console.log('=debug=', `Firebase Remote Operation: Using ${cfg.databaseURL}`)
+    }
+    return admin
+  }
+
+  static getDb(fbEnv: FirebaseEnvironment):admin.database.Database {
+    return this.getApp(fbEnv).database()
+  }
+
+  static backupDatabase(fbEnv: FirebaseEnvironment, backupDirPath: string): Promise<boolean> {
+    const db = RemoteProjectUtil.getApp(fbEnv).database()
+    db.goOnline()
+    return new Promise((resolve, reject) => {
+      const ref = db.ref('/');
+      console.log(`Requesting data from server: https://${fbEnv.config.projectId}.firebaseio.com`)
+      ref.once('value', (snapshot: any) => {
+        if (snapshot.exists()) {
+          if (!fs.existsSync(backupDirPath)) {
+            fs.mkdirSync(backupDirPath);
+          }
+          let backupPath = `${backupDirPath}/${fbEnv.config.projectId}-full_${Date.now()}.json`
+          console.log(`Database is populated. Backing up data to ${backupPath}`)
+          jsonFile.writeFileSync(backupPath, snapshot.val(), JSON_FILE_WRITE_CONFIG)
+          resolve(true)
+        } else {
+          resolve(false)
+        }
+        db.goOffline()
+      }, (e) => {
+        console.log('RemoteProjectUtil', 'Error', e)
+        reject(e)
+        db.goOffline()
+      })
+    })
+  }
+}
+
+
+
+

--- a/tools/gulp/project/model/firebase/firebase-private-key-config.ts
+++ b/tools/gulp/project/model/firebase/firebase-private-key-config.ts
@@ -1,4 +1,18 @@
-export const FirebasePrivateKeyTemplate = {
+
+export interface FirebasePrivateKeyConfig {
+  type: string
+  project_id: string
+  private_key_id: string
+  private_key: string
+  client_email: string
+  client_id: string
+  auth_uri: string
+  token_uri: string
+  auth_provider_x509_cert_url: string
+  client_x509_cert_url: string
+}
+
+export const FirebasePrivateKeyTemplate:FirebasePrivateKeyConfig = {
   'type': '',
   'project_id': '',
   'private_key_id': '',

--- a/tools/gulp/project/model/project-environment.ts
+++ b/tools/gulp/project/model/project-environment.ts
@@ -89,7 +89,7 @@ export class ProjectEnvironment implements ProjectEnvironmentJson {
       },
       projectUsers: DefaultUserTemplates.map(template => new ProjectUser(template, true))
     })
-    pe.firebase = FirebaseEnvironment.defaultProdEnv(pe)
+    pe.firebase = new FirebaseEnvironment(pe)
     return pe
   }
 

--- a/tools/gulp/project/model/project.ts
+++ b/tools/gulp/project/model/project.ts
@@ -31,7 +31,7 @@ export class Project implements ProjectJson {
     this.backupPath = cfg.backupPath || this.backupPath
     this.initialized = cfg.initialized === true
     let environments = cfg.environments || {}
-        Object.keys(environments).forEach(envKey => {
+    Object.keys(environments).forEach(envKey => {
       this.environments[envKey] = new ProjectEnvironment(this, cfg.environments[envKey])
     })
   }
@@ -39,12 +39,6 @@ export class Project implements ProjectJson {
   get environmentsAry() {
     return Object.keys(this.environments).map(key => this.environments[key])
   }
-
-  getNameFromPath(): string {
-    console.log('Project', 'getNameFromPath', path.basename(PROJECT_ROOT))
-    return path.basename(PROJECT_ROOT)
-  }
-
 
   getBackupPath() {
     let p = path.join(this.getBasePath(), this.backupPath)
@@ -63,6 +57,11 @@ export class Project implements ProjectJson {
     return path.join(this.getBasePath(), DEFAULT_CONFIG_FILE_NAME)
   }
 
+  getNameFromPath(): string {
+    console.log('Project', 'getNameFromPath', path.basename(PROJECT_ROOT))
+    return path.basename(PROJECT_ROOT)
+  }
+
   initLocal() {
     let configPath = this.getConfigFilePath()
     if (this.verifyConfigFileExists()) {
@@ -78,6 +77,7 @@ export class Project implements ProjectJson {
     this.write()
     console.log(`Wrote project configuration template to ${configPath}.`
       + `Edit this file to provide valid configuration for your project features.`)
+    console.log(`    === ${path.basename(configPath)} contains sensitive information and should NOT be committed to version control ===`)
   }
 
   updateLocal() {
@@ -100,6 +100,7 @@ export class Project implements ProjectJson {
     this.initialized = true
     this.backup()
     this.write()
+    console.log("Project validated successfully. Setting initialized to true: project is now ready for remote operations.")
   }
 
   backup() {


### PR DESCRIPTION
Now uses the project directory name to populate the various
name fields.

Validates one of the hardest to find errors on remote ops, which is
using the wrong firebase admin sdk key. Cannot help with invalid or
limited rights keys though. Only logging can catch those. I suppose
we could add a message interceptor and search the messages for errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ggranum/tangential/32)
<!-- Reviewable:end -->
